### PR TITLE
Fixed USAGE example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The certstreamcatcher is extremely simple, all you have to do is to import the l
 const certstreamcatcher = require('certstreamcatcher'); 
 const certstream = require("certstream");
 
-const regex = /(wellsfargo|paypal|login|sign-in|secure|update|money|sslsecure|amazon|)/gi; # Keywords
+const regex = /(wellsfargo|paypal|login|sign-in|secure|update|money|sslsecure|amazon)/gi; # Keywords
 
 const tlds = ['.io','.gq','.ml','.cf','.tk','.xyz','.pw','.cc']; # tlds 
 


### PR DESCRIPTION
Regexp /(wellsfargo|paypal|login|sign-in|secure|update|money|sslsecure|amazon|)/gi; was generating tons of false alerts due to | at the end